### PR TITLE
Update the coverage deployment action

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -21,6 +21,14 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
       - name: Run PHPUnit Tests
         run: vendor/bin/phpunit --coverage-html=coverage
+      # Rename Underscore Directories
+      - name: Rename Directories
+        run: |
+          mv coverage/_css coverage/css
+          mv coverage/_js coverage/js
+          mv coverage/_icons coverage/icons
+      - name: Fix Links in HTML Files
+        run: bash ./fix_coverage.sh
       - name: Deploy to GitHub Pages
         if: success()
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /vendor/
 /.idea/
+/.phpunit.cache/
+/coverage/
+/.phpunit.result.cache


### PR DESCRIPTION
Attempting to fix an issue where PHPUnit creates directories for CSS, JS, and Icons with underscores at the front which are ignored by GH Pages Jekyll implementation by default. This attempts to move those directories and then change all links within the generated HTML documents.