### PR TITLE
Add Native Asset Support and Enhance Unit Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,63 @@ require_once 'path/to/Bech32.php';
 ### Encoding
 
 ```php
-use PhpCardano\Bech32;
+use PhpCardano\Bech32\Bech32;
 
-$data = Bech32::hexToByteArray('your-data-hex-encoded-here');
-$hrp = 'addr'; // Human Readable Part (e.g., "addr" for Cardano addresses)
+// Set up our data to be encoded and our human readable part (HRP)
+$data = 'does-the-php-dev';
+$hrp = 'cardanophp';
+echo 'HRP: ' . $hrp . "\n" . ' Data: ' . $data . "\n";
 
-$encoded = Bech32Cardano::encode($hrp, $data);
-echo "Encoded: $encoded";
+// Hex-encode our data payload
+$hexdata = bin2hex($data);
+echo 'Hex Data: ' . $hexdata . "\n";
+
+// Convert our hex-encoded payload to a 5-bit "byte" array
+$bitdata = Bech32::hexToByteArray($hexdata);
+
+// Bech32 encode the HRP + 5-bit data payload
+$encoded = Bech32::encode($hrp, $bitdata);
+echo 'Encoded: ' . $encoded . "\n";
+```
+
+Expected Output:
+
+``` 
+HRP: cardanophp
+Data: does-the-php-dev
+Hex Data: 646f65732d7468652d7068702d646576
+Encoded: cardanophp1v3hk2uedw35x2ttsdpcz6er9wcjv4g3u
 ```
 
 ### Decoding
 
 ```php
-use PhpCardano\Bech32;
+use PhpCardano\Bech32\Bech32;
 
-$bech32 = 'addr1...'; // Your Bech32 string
+$bech32 = 'cardanophp1v3hk2uedw35x2ttsdpcz6er9wcjv4g3u'; // Your Bech32 string
 
-list($hrp, $data) = Bech32::decode($bech32);
-echo "HRP: $hrp\n";
-echo "Data: $data\n";
+// Decode returns the human readable part (HRP) and the data payload in a 5-bit array
+[$hrp, $bitData] = Bech32::decode($bech32);
+
+// Convert the 5-bit data back to a hex string
+$hexData = Bech32::byteArrayToHex($data);
+
+echo 'HRP: ' . $hrp . "\n";
+echo 'Hex Data: ' . $hexData . "\n";
+
+// Convert (if needed) from hex back to binary/ASCII
+
+$plainData = hex2bin($hexData);
+
+echo 'Data Payload: ' . $plainData . "\n";
+```
+
+Expected Output
+
+``` 
+HRP: cardanophp
+Hex Data: 646f65732d7468652d7068702d646576
+Data Payload: does-the-php-dev
 ```
 
 ### Decoding a Cardano Address
@@ -58,6 +96,8 @@ Example PHP Code:
 /**
 * JPG v2 Staked Public Contract
 **/
+
+use CardanoPhp\Bech32\Bech32;
 
 $bech32String = 'addr1qxegfu8m62peqmyamrdwmwqm00zjcak3u25xnanfdct4p9pf488uagw68fv50kjxv3wrx38829tay6zszthnccsradgqwt4upy';
 $result = Bech32::decodeCardanoAddress($bech32String);
@@ -86,6 +126,8 @@ Example PHP Code:
 /**
 * JPG v2 Staked Public Contract
 **/
+
+use CardanoPhp\Bech32\Bech32;
 
 $addressType = 3;                                                          // Script Hash + Script Hash
 $networkId = 1;                                                            // Cardano Mainnet

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ]
   },
   "require": {
-    "php": "^8.2"
+    "php": "^8.2",
+    "ext-sodium": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.5"

--- a/src/Bech32.php
+++ b/src/Bech32.php
@@ -20,10 +20,11 @@ use function strlen;
  */
 class Bech32
 {
-    const GENERATOR   = [
+    const GENERATOR = [
         0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
     ];
 
+    // Valid characters in a Bech32-encoded data portion
     const CHARSET     = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
 
     const CHARKEY_KEY = [
@@ -36,14 +37,50 @@ class Bech32
         19, -1, 1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1,
     ];
 
+    // HRM must be at least 1 character in length
+    const MIN_HRP_LENGTH = 1;
+
+    // HRP must be at most 83 characters in length
+    const MAX_HRP_LENGTH = 83;
+
+    // Printable ASCII Characters from ! (33) through ~ (126)
+    const HRP_REGEX = "/[\x21-\x7e]{1,83}/";
+
+    // There must be at least 6 characters in the data portion of a valid Bech32 encoding
+    const MIN_DATA_LENGTH = 6;
+
+    // This character is reserved as the separator between the human readable
+    // part (HRP) and the data. The HRP may contain te separator character so
+    // the final occurrence of the separator character in the Bech32-encoded
+    // string is considered to be the separator demarcation between HRP and data
+    const SEPARATOR_CHARACTER = '1';
+
+    // The minimum length of a valid bech32 string is the minimum length of the
+    // HRP, the character length of the separator character, and the minimum
+    // length of the data. i.e. 1 + 1 + 6 = 8
+    const BECH32_MIN_LENGTH = 8;
+
     /**
      * @param string $hrp
      * @param array  $combinedDataChars
      *
      * @return string
+     * @throws Exception
      */
     public static function encode(string $hrp, array $combinedDataChars): string
     {
+        if (strlen($hrp) < self::MIN_HRP_LENGTH) {
+            throw new Exception('HRP too short');
+        }
+
+        if (strlen($hrp) > self::MAX_HRP_LENGTH) {
+            throw new Exception('HRP too long');
+        }
+
+        if (!preg_match(self::HRP_REGEX, $hrp)) {
+            throw new Exception('Invalid characters in HRP');
+        }
+
         $checksum = self::createChecksum($hrp, $combinedDataChars);
         $characters = array_merge($combinedDataChars, $checksum);
 
@@ -52,7 +89,7 @@ class Bech32
             $encoded[$i] = self::CHARSET[$characters[$i]];
         }
 
-        return "{$hrp}1" . implode('', $encoded);
+        return $hrp . self::SEPARATOR_CHARACTER . implode('', $encoded);
     }
 
     /**
@@ -68,7 +105,7 @@ class Bech32
     public static function decode(string $sBech): array
     {
         $length = strlen($sBech);
-        if ($length < 8) {
+        if ($length < self::BECH32_MIN_LENGTH) {
             throw new Exception("Bech32 string is too short");
         }
 
@@ -80,7 +117,7 @@ class Bech32
 
         for ($i = 0; $i < $length; $i++) {
             $x = $chars[$i];
-            if ($x <= 33 || $x >= 126) {
+            if ($x < 33 || $x > 126) {
                 throw new Exception('Out of range character in Bech32 string');
             }
 
@@ -100,15 +137,19 @@ class Bech32
         }
 
         if ($haveUpper && $haveLower) {
-            throw new Exception('Data contains mixture of higher/lower case characters');
+            throw new Exception('Data contains mixed case characters');
         }
 
         if ($positionOne === -1) {
             throw new Exception("Missing separator character");
         }
 
-        if ($positionOne < 1) {
-            throw new Exception("Empty HRP");
+        if ($positionOne < self::MIN_HRP_LENGTH) {
+            throw new Exception("HRP too short");
+        }
+
+        if ($positionOne > self::MAX_HRP_LENGTH) {
+            throw new Exception("HRP too long");
         }
 
         if (($positionOne + 7) > $length) {
@@ -116,6 +157,12 @@ class Bech32
         }
 
         $hrp = pack("C*", ...array_slice($chars, 0, $positionOne));
+        $dataS = pack("C*", ...array_slice($chars, $positionOne + 1));
+        $validDataRegex = "/^[" . self::CHARSET . "]+$/";
+
+        if (!preg_match($validDataRegex, $dataS)) {
+            throw new Exception("Invalid characters in Bech32 data");
+        }
 
         $data = [];
         for ($i = $positionOne + 1; $i < $length; $i++) {
@@ -360,10 +407,6 @@ class Bech32
             $addressType, $networkId,
         ] = self::decodeAddressHeader(substr($hexPayload, 0, 2));
 
-        /*        echo json_encode([
-                        'addressType' => $addressType, 'networkId' => $networkId,
-                    ]) . "\n";*/
-
         if ($networkId && $hrp !== 'addr') {
             throw new Exception("HRP does not match network ID");
         }
@@ -372,7 +415,6 @@ class Bech32
             throw new Exception("HRP does not match network ID");
         }
 
-        $networkSuffix = self::networkIdToBinary($networkId);
         $payloadHex = substr($hexPayload, 2);
 
         /**
@@ -387,8 +429,6 @@ class Bech32
          * 7: 0111.... ScriptHash (Enterprise)
          */
         $stakingKeyHash = '';
-        $stakeKeyPrefix = self::addressTypeToStakePrefixBinary($addressType);
-        $stakeAddress = null;
 
         switch ($addressType) {
             case 0: // PaymentKeyHash + StakeKeyHash
@@ -438,17 +478,6 @@ class Bech32
         }
 
         $stakeAddress = self::encodeCardanoStakeAddress($networkId, $addressType, $stakeHash);
-        //        else {
-        //            if ($addressType < 3 && !empty($stakeHash)) {
-        //                $stakeTypeHeader = self::addressTypeToStakePrefixBinary($addressType);
-        //                $stakeNetworkHeader = $addressNetworkHeader;
-        //                $stakeAddressPrefix = dechex(bindec($stakeTypeHeader . $stakeNetworkHeader));
-        //                $stakeAddressHex = $stakeAddressPrefix . $stakeHash;
-        //                $stakeHrp = $networkId ? 'stake' : 'stake_test';
-        //                $stakeAddressBytes = self::hexToByteArray($stakeAddressHex);
-        //                $stakeAddress = self::encode($stakeHrp, $stakeAddressBytes);
-        //            }
-        //        }
 
         $addressBytes = self::hexToByteArray($addressHeader . $paymentHash . $stakeHash);
 
@@ -600,6 +629,11 @@ class Bech32
      */
     public static function hashNativeAsset(string $policyId, string $assetName): string
     {
+        // TODO: Add sanity checking here...
+        // TODO: - Policy ID must be a 56-characer hex-encoded string
+        // TODO: - Asset Name must be between a 0-64-character hex-encoded string
+        // TODO: - Check that sodium extension is enabled an throw exception if now
+
         $assetBinary = sodium_hex2bin($policyId . $assetName);
         // For sodium_crypto_generichash the length is specified in bytes so 20B = 160b
         $b2Sum = sodium_crypto_generichash($assetBinary, "", 20);
@@ -629,5 +663,16 @@ class Bech32
         return self::encode('asset', $payload);
     }
 
-
+    public static function decodeNativeAsset(string $bech32): string
+    {
+        // TODO: Add some sanity checking here...
+        // TODO: - Must begin with `asset`
+        if (!str_starts_with($bech32, 'asset')) {
+            throw new Exception("Invalid hrp");
+        }
+        // TODO: - Must be a fixed length
+        if (strlen($bech32) !== 44) {
+            throw new Exception("A Cardano native asset fingerprint must be 44 characters");
+        }
+    }
 }

--- a/src/Bech32.php
+++ b/src/Bech32.php
@@ -44,7 +44,7 @@ class Bech32
     const MAX_HRP_LENGTH = 83;
 
     // Printable ASCII Characters from ! (33) through ~ (126)
-    const HRP_REGEX = "/[\x21-\x7e]{1,83}/";
+    const HRP_REGEX = "/^[\x21-\x7e]{1,83}$/";
 
     // For quick and easy checking that a hex-string has been provided
     const HEX_REGEX = '/^[0-9A-F]*$/i';

--- a/tests/Bech32AssetTest.php
+++ b/tests/Bech32AssetTest.php
@@ -16,28 +16,44 @@ class Bech32AssetTest extends TestCase
     }
 
     #[DataProvider('assetProvider')]
-    public function testManualAssetEncoding($policyId, $assetName, $assetFingerprint)
+    public function testManualAssetEncoding($policyId, $assetName, $assetHash, $assetFingerprint)
     {
         $hash = Bech32::hashNativeAsset($policyId, $assetName);
+        $this->assertEquals($assetHash, $hash);
         $result = Bech32::encode('asset', Bech32::hexToByteArray($hash));
         $this->assertEquals($assetFingerprint, $result);
     }
 
     #[DataProvider('assetProvider')]
-    public function testAutomaticAssetEncoding($policyId, $assetName, $assetFingerprint)
+    public function testAutomaticAssetEncoding($policyId, $assetName, $assetHash, $assetFingerprint)
     {
         $result = Bech32::encodeNativeAsset($policyId, $assetName);
-        $this->assertEquals($assetFingerprint, $result);
+        $this->assertEquals([
+            'policyId'  => $policyId, 'assetName' => $assetName,
+            'assetHash' => $assetHash, 'assetFingerprint' => $assetFingerprint,
+        ], $result);
     }
 
     #[DataProvider('assetProvider')]
-    public function testManualAssetDecoding($policyId, $assetName, $assetFingerprint)
+    public function testManualAssetDecoding($policyId, $assetName, $assetHash, $assetFingerprint)
     {
         $hash = Bech32::hashNativeAsset($policyId, $assetName);
+        $this->assertEquals($assetHash, $hash);
         [$hrp, $data] = Bech32::decode($assetFingerprint);
         $decodedHash = Bech32::byteArrayToHex($data);
 
         $this->assertEquals('asset', $hrp);
         $this->assertEquals($hash, $decodedHash);
+    }
+
+    #[DataProvider('assetProvider')]
+    public function testAutomaticAssetDecoding($policyId, $assetName, $assetHash, $assetFingerprint)
+    {
+        $hash = Bech32::hashNativeAsset($policyId, $assetName);
+        $this->assertEquals($assetHash, $hash);
+        $result = Bech32::decodeNativeAsset($assetFingerprint);
+        $this->assertEquals([
+            'assetHash' => $assetHash, 'assetFingerprint' => $assetFingerprint,
+        ], $result);
     }
 }

--- a/tests/Bech32AssetTest.php
+++ b/tests/Bech32AssetTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CardanoPhp\Bech32;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Bech32::class)]
+class Bech32AssetTest extends TestCase
+{
+    public static function assetProvider(): array
+    {
+        // Test vectors are defined in ./cip14-vectors.json
+        return json_decode(file_get_contents(__DIR__ . '/cip14-vectors.json'), true);
+    }
+
+    #[DataProvider('assetProvider')]
+    public function testManualAssetEncoding($policyId, $assetName, $assetFingerprint)
+    {
+        $hash = Bech32::hashNativeAsset($policyId, $assetName);
+        $result = Bech32::encode('asset', Bech32::hexToByteArray($hash));
+        $this->assertEquals($assetFingerprint, $result);
+    }
+
+    #[DataProvider('assetProvider')]
+    public function testAutomaticAssetEncoding($policyId, $assetName, $assetFingerprint)
+    {
+        $result = Bech32::encodeNativeAsset($policyId, $assetName);
+        $this->assertEquals($assetFingerprint, $result);
+    }
+
+    #[DataProvider('assetProvider')]
+    public function testManualAssetDecoding($policyId, $assetName, $assetFingerprint)
+    {
+        $hash = Bech32::hashNativeAsset($policyId, $assetName);
+        [$hrp, $data] = Bech32::decode($assetFingerprint);
+        $decodedHash = Bech32::byteArrayToHex($data);
+
+        $this->assertEquals('asset', $hrp);
+        $this->assertEquals($hash, $decodedHash);
+    }
+}

--- a/tests/Bech32BadAssetTest.php
+++ b/tests/Bech32BadAssetTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CardanoPhp\Bech32;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Bech32::class)]
+class Bech32BadAssetTest extends TestCase
+{
+    public static function invalidAssetProvider(): array
+    {
+        // Test vectors are defined in ./cip14-vectors.json
+        return json_decode(file_get_contents(__DIR__ . '/cip14-invalid-vectors.json'), true);
+    }
+
+    #[DataProvider('invalidAssetProvider')]
+    public function testInvalidAssets($policyId, $assetName, $assetFingerprint, $test, $exception)
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage($exception);
+        switch ($test) {
+            case 'encode':
+                Bech32::encodeNativeAsset($policyId, $assetName);
+                break;
+            case 'decode':
+                Bech32::decodeNativeAsset($assetFingerprint);
+                break;
+        }
+    }
+}

--- a/tests/Bech32Test.php
+++ b/tests/Bech32Test.php
@@ -31,6 +31,62 @@ class Bech32Test extends TestCase
         $this->assertEquals($expectedDataChars, $dataChars);
     }
 
+    public function testEncodeHrpTooShort()
+    {
+        $expectedBech32String = '10pqtlnyq06v';
+        $hrp = '';
+        $dataChars = [15, 1, 0, 11, 31];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('HRP too short');
+
+        $result = Bech32::encode($hrp, $dataChars);
+    }
+
+    public function testEncodeHrpTooLong()
+    {
+        $expectedBech32String = 'an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio10pqtlnyq06v';
+        $hrp = 'an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio';
+        $dataChars = [15, 1, 0, 11, 31];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('HRP too long');
+
+        $result = Bech32::encode($hrp, $dataChars);
+    }
+
+    public function testEncodeSpaceInHrp()
+    {
+        $expectedBech32String = "addr test10pqtlnyq06v";
+        $hrp = "addr test";
+        $dataChars = [15, 1, 0, 11, 31];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid characters in HRP');
+
+        $result = Bech32::encode($hrp, $dataChars);
+    }
+
+    public function testDecodeSpaceInBech32()
+    {
+        $bech32String = "addr test10pqtlnyq06v";
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Out of range character in Bech32 string');
+
+        $result = Bech32::decode($bech32String);
+    }
+
+    public function testDecodeHrpTooLong()
+    {
+        $bech32String = 'an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio10pqtlnyq06v';
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('HRP too long');
+
+        $result = Bech32::decode($bech32String);
+    }
+
     public function testDecodeMissingSeparatorCharacter()
     {
         $this->expectException(Exception::class);

--- a/tests/Bech32Test.php
+++ b/tests/Bech32Test.php
@@ -293,5 +293,4 @@ class Bech32Test extends TestCase
         Bech32::encodeCardanoAddress(0, 1, '9068a7a3f008803edac87af1619860f2cdcde40c26987325ace138ad');
     }
 
-
 }

--- a/tests/Bech32Test.php
+++ b/tests/Bech32Test.php
@@ -69,7 +69,7 @@ class Bech32Test extends TestCase
     public function testDecodeMissingHrp()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Empty HRP');
+        $this->expectExceptionMessage('HRP too short');
 
         Bech32::decode('1qqqqqqqq');
     }
@@ -85,7 +85,7 @@ class Bech32Test extends TestCase
     public function testDecodeInvalidCharacterRange()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage("Out of range character in Bech32 string");
+        $this->expectExceptionMessage("Invalid characters in Bech32 data");
 
         Bech32::decode("test1!qqqqqqqq");
     }
@@ -93,7 +93,7 @@ class Bech32Test extends TestCase
     public function testDecodeMixedCase()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage("Data contains mixture of higher/lower case characters");
+        $this->expectExceptionMessage("Data contains mixed case characters");
 
         Bech32::decode("TeSt1pqqq0");
     }

--- a/tests/cip14-invalid-vectors.json
+++ b/tests/cip14-invalid-vectors.json
@@ -1,0 +1,51 @@
+[
+  {
+    "policyId": "7eae28",
+    "assetName": "504154415445",
+    "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92",
+    "test": "encode",
+    "exception": "A Cardano native asset Policy ID must be 56 characters"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc3731",
+    "assetName": "504154415445",
+    "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92",
+    "test": "encode",
+    "exception": "A Cardano native asset Policy ID must be 56 characters"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "00000000000000000000000000000000000000000000000000000000000000001",
+    "assetFingerprint": "asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w",
+    "test": "encode",
+    "exception": "AssetName too long"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc37z",
+    "assetName": "504154415445",
+    "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92",
+    "test": "encode",
+    "exception": "PolicyId contains invalid characters"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "504154415445q",
+    "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92",
+    "test": "encode",
+    "exception": "AssetName contains invalid characters"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "504154415445",
+    "assetFingerprint": "token13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92",
+    "test": "decode",
+    "exception": "Invalid hrp"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "504154415445",
+    "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde9",
+    "test": "decode",
+    "exception": "A Cardano native asset fingerprint must be 44 characters"
+  }
+]

--- a/tests/cip14-vectors.json
+++ b/tests/cip14-vectors.json
@@ -1,0 +1,42 @@
+[
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "",
+    "assetFingerprint": "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc37e",
+    "assetName": "",
+    "assetFingerprint": "asset1nl0puwxmhas8fawxp8nx4e2q3wekg969n2auw3"
+  },
+  {
+    "policyId": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
+    "assetName": "",
+    "assetFingerprint": "asset1uyuxku60yqe57nusqzjx38aan3f2wq6s93f6ea"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "504154415445",
+    "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92"
+  },
+  {
+    "policyId": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
+    "assetName": "504154415445",
+    "assetFingerprint": "asset1hv4p5tv2a837mzqrst04d0dcptdjmluqvdx9k3"
+  },
+  {
+    "policyId": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
+    "assetName": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetFingerprint": "asset1aqrdypg669jgazruv5ah07nuyqe0wxjhe2el6f"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
+    "assetFingerprint": "asset17jd78wukhtrnmjh3fngzasxm8rck0l2r4hhyyt"
+  },
+  {
+    "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetName": "0000000000000000000000000000000000000000000000000000000000000000",
+    "assetFingerprint": "asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w"
+  }
+]

--- a/tests/cip14-vectors.json
+++ b/tests/cip14-vectors.json
@@ -2,41 +2,49 @@
   {
     "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
     "assetName": "",
+    "assetHash": "1cadfc0e7068801d51d240d14a4085f2a3673cbb",
     "assetFingerprint": "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3"
   },
   {
     "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc37e",
     "assetName": "",
+    "assetHash": "9fde1e38dbbf6074f5c609e66ae5408bb3641745",
     "assetFingerprint": "asset1nl0puwxmhas8fawxp8nx4e2q3wekg969n2auw3"
   },
   {
     "policyId": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
     "assetName": "",
+    "assetHash": "e1386b734f20334f4f9000a4689fbd9c52a70350",
     "assetFingerprint": "asset1uyuxku60yqe57nusqzjx38aan3f2wq6s93f6ea"
   },
   {
     "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
     "assetName": "504154415445",
+    "assetHash": "8cd54e31e4ea696e42344ed563eb00269e2a1da5",
     "assetFingerprint": "asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92"
   },
   {
     "policyId": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
     "assetName": "504154415445",
+    "assetHash": "bb2a1a2d8ae9e3ed880382df56bdb80adb2dff80",
     "assetFingerprint": "asset1hv4p5tv2a837mzqrst04d0dcptdjmluqvdx9k3"
   },
   {
     "policyId": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
     "assetName": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
+    "assetHash": "e806d2051ad1648e887c653b77fa7c2032f71a57",
     "assetFingerprint": "asset1aqrdypg669jgazruv5ah07nuyqe0wxjhe2el6f"
   },
   {
     "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
     "assetName": "1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209",
+    "assetHash": "f49be3bb96bac73dcaf14cd02ec0db38f167fd43",
     "assetFingerprint": "asset17jd78wukhtrnmjh3fngzasxm8rck0l2r4hhyyt"
   },
   {
     "policyId": "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
     "assetName": "0000000000000000000000000000000000000000000000000000000000000000",
+    "assetHash": "0d82e25a7f673fee89e631f02bff4f0933fad061",
     "assetFingerprint": "asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w"
   }
 ]


### PR DESCRIPTION
Add support and helper functions and unit tests for encoding and decoding Cardano Native Assets into an "Asset Fingerprint" which is a more human-friendly identifier defined in [CIP-0014](https://github.com/cardano-foundation/CIPs/tree/6424b4fd8c76e61b78feb303182a7aa61453e78d/CIP-0014).

- Resolves #8 
- Fixes #2